### PR TITLE
add has-read and to-be-read buttons with db integration

### DIFF
--- a/components/_taliwind-colors-safelist.tsx
+++ b/components/_taliwind-colors-safelist.tsx
@@ -1,0 +1,7 @@
+export const TailwindColorSafelist = () => {
+  return (
+    <div className="hidden">
+      <div className="bg-info-500/70 bg-info-500/70 bg-warning-500/70 bg-success-500/70 bg-danger-500/70" />
+    </div>
+  )
+}

--- a/components/book-details/book-sidebar.tsx
+++ b/components/book-details/book-sidebar.tsx
@@ -6,6 +6,8 @@ import { Toaster } from '@/components/ui/sonner'
 import FavouriteButton from '../library-interactions/favourite-button'
 import WishListButton from '../library-interactions/wishlist-button'
 import HasBookButton from '../library-interactions/has-book-button'
+import HasReadButton from '../library-interactions/has-read-button'
+import ToBeReadButton from '../library-interactions/to-be-read'
 
 const BookSidebar = ({ book }: { book: Book }) => {
   return (
@@ -49,6 +51,18 @@ const BookSidebar = ({ book }: { book: Book }) => {
         workId={book.workId}
       />
       <HasBookButton
+        title={book.title}
+        authors={book.authors}
+        coverUrl={book.coverUrl}
+        workId={book.workId}
+      />
+      <HasReadButton
+        title={book.title}
+        authors={book.authors}
+        coverUrl={book.coverUrl}
+        workId={book.workId}
+      />
+      <ToBeReadButton
         title={book.title}
         authors={book.authors}
         coverUrl={book.coverUrl}

--- a/components/library-interactions/favourite-button.tsx
+++ b/components/library-interactions/favourite-button.tsx
@@ -53,7 +53,7 @@ const FavouriteButton = ({
       >
         {isFavourite ? (
           <>
-            <Heart className="text-rose-500" fill="oklch(64.5% 0.246 16.439)" />
+            <Heart fill="oklch(65% 0.16 18)" />
             In favourites
           </>
         ) : (

--- a/components/library-interactions/handleBookStatusToggle.tsx
+++ b/components/library-interactions/handleBookStatusToggle.tsx
@@ -61,7 +61,7 @@ export const handleBookStatusToggle = async ({
   toast(
     <CustomToast
       message={currentValue ? toastMessages.off : toastMessages.on}
-      color="bg-info-200/70"
+      color="bg-info-500/70"
     />,
     { unstyled: true }
   )

--- a/components/library-interactions/has-read-button.tsx
+++ b/components/library-interactions/has-read-button.tsx
@@ -1,13 +1,13 @@
 'use client'
 
-import { LibraryBig } from 'lucide-react'
+import { Book, BookCheck } from 'lucide-react'
 import { Button } from '../ui/button'
 import { BookButtonProps } from '@/interfaces'
 import { useSessionStatus } from '@/lib/hooks/useSessionStatus'
 import { useBookStatus } from '@/lib/hooks/useBookStatus'
 import { handleBookStatusToggle } from './handleBookStatusToggle'
 
-const HasBookButton = ({
+const HasReadButton = ({
   title,
   authors,
   coverUrl,
@@ -17,8 +17,8 @@ const HasBookButton = ({
 
   const {
     bookId,
-    statusValue: hasBook,
-    setStatusValue: setHasBook,
+    statusValue: hasRead,
+    setStatusValue: setHasRead,
     isBookStatusLoading,
   } = useBookStatus({
     workId,
@@ -26,7 +26,7 @@ const HasBookButton = ({
     authors,
     coverUrl,
     userId,
-    column: 'has_book',
+    column: 'has_read',
   })
 
   const handleClick = async () => {
@@ -34,12 +34,12 @@ const HasBookButton = ({
       isLoggedIn,
       userId,
       bookId,
-      column: 'has_book',
-      currentValue: hasBook,
-      setValue: setHasBook,
+      column: 'has_read',
+      currentValue: hasRead,
+      setValue: setHasRead,
       toastMessages: {
-        on: 'Added to your bookshelf',
-        off: 'Removed from your bookshelf',
+        on: 'Added to your read pile',
+        off: 'Removed from your read pile',
       },
     })
   }
@@ -50,14 +50,15 @@ const HasBookButton = ({
         disabled={isSessionLoading || isBookStatusLoading}
         variant="outline"
       >
-        {hasBook ? (
+        {hasRead ? (
           <>
-            <LibraryBig fill="oklch(0.63 0.045 50)" />I own this
+            <BookCheck fill="oklch(0.66 0.04 140)" />
+            I've read this
           </>
         ) : (
           <>
-            <LibraryBig />
-            Mark as owned
+            <Book />
+            Mark as read
           </>
         )}
       </Button>
@@ -65,4 +66,4 @@ const HasBookButton = ({
   )
 }
 
-export default HasBookButton
+export default HasReadButton

--- a/components/library-interactions/to-be-read.tsx
+++ b/components/library-interactions/to-be-read.tsx
@@ -1,13 +1,13 @@
 'use client'
 
-import { LibraryBig } from 'lucide-react'
+import { BookOpen } from 'lucide-react'
 import { Button } from '../ui/button'
 import { BookButtonProps } from '@/interfaces'
 import { useSessionStatus } from '@/lib/hooks/useSessionStatus'
 import { useBookStatus } from '@/lib/hooks/useBookStatus'
 import { handleBookStatusToggle } from './handleBookStatusToggle'
 
-const HasBookButton = ({
+const ToBeReadButton = ({
   title,
   authors,
   coverUrl,
@@ -17,8 +17,8 @@ const HasBookButton = ({
 
   const {
     bookId,
-    statusValue: hasBook,
-    setStatusValue: setHasBook,
+    statusValue: toBeRead,
+    setStatusValue: setToBeRead,
     isBookStatusLoading,
   } = useBookStatus({
     workId,
@@ -26,7 +26,7 @@ const HasBookButton = ({
     authors,
     coverUrl,
     userId,
-    column: 'has_book',
+    column: 'to_be_read',
   })
 
   const handleClick = async () => {
@@ -34,12 +34,12 @@ const HasBookButton = ({
       isLoggedIn,
       userId,
       bookId,
-      column: 'has_book',
-      currentValue: hasBook,
-      setValue: setHasBook,
+      column: 'to_be_read',
+      currentValue: toBeRead,
+      setValue: setToBeRead,
       toastMessages: {
-        on: 'Added to your bookshelf',
-        off: 'Removed from your bookshelf',
+        on: 'Added to your to-read pile',
+        off: 'Removed from to-read pile',
       },
     })
   }
@@ -50,14 +50,14 @@ const HasBookButton = ({
         disabled={isSessionLoading || isBookStatusLoading}
         variant="outline"
       >
-        {hasBook ? (
+        {toBeRead ? (
           <>
-            <LibraryBig fill="oklch(0.63 0.045 50)" />I own this
+            <BookOpen fill="oklch(0.73 0.05 80)" />I want to read this
           </>
         ) : (
           <>
-            <LibraryBig />
-            Mark as owned
+            <BookOpen />
+            Put in to-read pile
           </>
         )}
       </Button>
@@ -65,4 +65,4 @@ const HasBookButton = ({
   )
 }
 
-export default HasBookButton
+export default ToBeReadButton

--- a/components/library-interactions/wishlist-button.tsx
+++ b/components/library-interactions/wishlist-button.tsx
@@ -52,10 +52,7 @@ const WishListButton = ({
       >
         {isInWishList ? (
           <>
-            <Bookmark
-              className="text-accent-500"
-              fill="oklch(64.9% 0.12 35.14)"
-            />
+            <Bookmark fill="oklch(77% 0.13 85)" />
             In wishlist
           </>
         ) : (


### PR DESCRIPTION
This PR:
- adds a to-be-read-button with Supabase integration
- adds a has-read button with Supabase integration
- adds a tailwind colors safelist, so that the dynamic classes in the CustomToast work properly