### PR TITLE
Feat/infinite scroll

### DIFF
--- a/components/search/book-list-card.tsx
+++ b/components/search/book-list-card.tsx
@@ -12,6 +12,7 @@ const BookListCard = ({ book }: { book: BookLite }) => {
           ? `/book/${book.workId}?edition=${book.editionKey}`
           : `/book/${book.workId}`
       }
+      className="book-item"
     >
       <Card className="flex flex-col items-center bg-background-100 justify-between text-text-500 transition-transform duration-300 hover:-translate-y-1 hover:shadow-xl h-full">
         <Image src="/decoration-2-top.svg" alt="" width={142} height={20} />

--- a/components/search/book-list.tsx
+++ b/components/search/book-list.tsx
@@ -4,8 +4,8 @@ import BookListCard from './book-list-card'
 const BookList = ({ books }: { books: BookLite[] }) => {
   return (
     <div className="mt-8 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8 max-w-6xl mx-auto px-4">
-      {books.map((book) => (
-        <BookListCard key={book.workId} book={book} />
+      {books.map((book, i) => (
+        <BookListCard key={i} book={book} />
       ))}
     </div>
   )

--- a/components/search/book-list.tsx
+++ b/components/search/book-list.tsx
@@ -3,7 +3,7 @@ import BookListCard from './book-list-card'
 
 const BookList = ({ books }: { books: BookLite[] }) => {
   return (
-    <div className="mt-8 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8 max-w-6xl mx-auto px-4">
+    <div className="mt-8 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8 max-w-6xl mx-auto px-4 ">
       {books.map((book, i) => (
         <BookListCard key={i} book={book} />
       ))}

--- a/components/search/index.tsx
+++ b/components/search/index.tsx
@@ -10,6 +10,7 @@ import { fetchBooksLite } from '@/lib/api'
 import BookListSkeleton from './book-list-skeleton'
 import BookList from './book-list'
 import { useInfiniteScroll } from '@/lib/hooks/useInfiniteScroll'
+import { Button } from '../ui/button'
 
 const Search = () => {
   const router = useRouter()
@@ -151,6 +152,24 @@ const Search = () => {
     router.push(`/search?q=${encodeURIComponent(query)}&type=${type}&page=1`)
   }
 
+  const handleBackToTop = async () => {
+    window.scrollTo({ top: 0, behavior: 'smooth' })
+
+    setBooks([])
+
+    setPage(1)
+    setHasMore(true)
+    setPagePositions({})
+
+    const params = new URLSearchParams(searchParams.toString())
+    params.set('page', '1')
+    router.replace(`/search?${params.toString()}`, { scroll: false })
+
+    setTimeout(() => {
+      handleFetch(queryParam, typeParam, pageSize.toString(), 1)
+    }, 300)
+  }
+
   const showNoResults =
     !loading && !error && books.length === 0 && queryParam && searchCompleted
 
@@ -175,11 +194,21 @@ const Search = () => {
       )}
 
       {!loading && books.length > 0 && (
-        <div ref={bookListRef}>
-          <BookList books={books} />
-          {isFetchingMore && <BookListSkeleton />}
-          <div ref={loadMoreRef} className="h-10" />
-        </div>
+        <>
+          <div ref={bookListRef}>
+            <BookList books={books} />
+            {isFetchingMore && <BookListSkeleton />}
+            <div ref={loadMoreRef} className="h-10" />
+          </div>
+          {page > 1 && (
+            <Button
+              className="fixed bottom-10 right-10"
+              onClick={handleBackToTop}
+            >
+              Back to top
+            </Button>
+          )}
+        </>
       )}
     </div>
   )

--- a/components/search/index.tsx
+++ b/components/search/index.tsx
@@ -9,6 +9,7 @@ import SearchBar from './search-bar'
 import { fetchBooksLite } from '@/lib/api'
 import BookListSkeleton from './book-list-skeleton'
 import BookList from './book-list'
+import { useInfiniteScroll } from '@/lib/hooks/useInfiniteScroll'
 
 const Search = () => {
   const router = useRouter()
@@ -16,63 +17,89 @@ const Search = () => {
 
   const queryParam = searchParams.get('q') || ''
   const typeParam = (searchParams.get('type') as SearchType) || 'all'
-  const limitParam = searchParams.get('limit') || '20'
 
   const [searchQuery, setSearchQuery] = useState(queryParam)
   const [searchType, setSearchType] = useState<SearchType>(typeParam)
-  const [searchLimit, setSearchLimit] = useState(limitParam)
   const [books, setBooks] = useState<Book[]>([])
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [searchCompleted, setSearchCompleted] = useState(false)
 
+  const [page, setPage] = useState(1)
+  const [hasMore, setHasMore] = useState(true)
+  const [isFetchingMore, setIsFetchingMore] = useState(false)
+
+  const pageSize = '30'
+
   useEffect(() => {
     if (queryParam.trim()) {
-      handleFetch(queryParam, typeParam, limitParam)
+      setBooks([])
+      setSearchCompleted(false)
+      setIsFetchingMore(false)
+      setHasMore(true)
+      setPage(1)
+
+      handleFetch(queryParam, typeParam, pageSize, 1) // ← force it!
     } else {
       setBooks([])
       setSearchCompleted(false)
     }
-  }, [queryParam, typeParam, limitParam])
+  }, [queryParam, typeParam])
 
   const handleFetch = async (
     query: string,
     type: SearchType,
-    limit: string
+    limit: string,
+    page: number
   ) => {
-    setLoading(true)
+    if (page === 1) {
+      setLoading(true)
+      setBooks([])
+    } else {
+      setIsFetchingMore(true)
+    }
+
     setError(null)
-    setSearchCompleted(false)
+    if (page === 1) setSearchCompleted(false)
 
     try {
-      const results = await fetchBooksLite(query, type, limit)
-      setBooks(results)
-      console.log(results)
+      const results = await fetchBooksLite(query, type, limit, page)
+
+      if (page === 1) {
+        setBooks(results)
+      } else {
+        setBooks((prev) => [...prev, ...results])
+      }
+
+      setHasMore(results.length === parseInt(limit))
     } catch (err) {
       console.error(err)
       setError('Something went wrong while fetching books.')
+      setHasMore(false)
     } finally {
       setLoading(false)
+      setIsFetchingMore(false)
       setSearchCompleted(true)
     }
   }
 
-  const handleSearch = (
-    query: string,
-    type: SearchType = 'all',
-    limit: string = '20'
-  ) => {
+  const loadMoreRef = useInfiniteScroll(() => {
+    if (!isFetchingMore && hasMore) {
+      handleFetch(queryParam, typeParam, pageSize, page + 1)
+      setPage((prev) => prev + 1)
+    }
+  }, hasMore)
+
+  const handleSearch = (query: string, type: SearchType = 'all') => {
     // If the search parameters haven't changed, don't trigger a new search
-    if (query === searchQuery && type === searchType && limit === searchLimit) {
+    if (query === searchQuery && type === searchType) {
       return
     }
 
     setSearchQuery(query)
     setSearchType(type)
-    setSearchLimit(limit)
-    router.push(
-      `/search?q=${encodeURIComponent(query)}&type=${type}&limit=${limit}`
-    )
+
+    router.push(`/search?q=${encodeURIComponent(query)}&type=${type}`)
   }
 
   const showNoResults =
@@ -84,7 +111,6 @@ const Search = () => {
         onSearch={handleSearch}
         initialQuery={searchQuery}
         initialType={searchType}
-        initialLimit={searchLimit}
       />
 
       {loading && <BookListSkeleton />}
@@ -99,7 +125,13 @@ const Search = () => {
         </div>
       )}
 
-      {!loading && books.length > 0 && <BookList books={books} />}
+      {!loading && books.length > 0 && (
+        <>
+          <BookList books={books} />
+          {isFetchingMore && <BookListSkeleton />}
+          <div ref={loadMoreRef} className="h-10" />
+        </>
+      )}
     </div>
   )
 }

--- a/components/search/index.tsx
+++ b/components/search/index.tsx
@@ -4,7 +4,7 @@ import { Book } from '@/interfaces'
 import { SearchType } from '@/types'
 import { useSearchParams } from 'next/navigation'
 import { useRouter } from 'next/navigation'
-import { useEffect, useState } from 'react'
+import { useEffect, useState, useRef } from 'react'
 import SearchBar from './search-bar'
 import { fetchBooksLite } from '@/lib/api'
 import BookListSkeleton from './book-list-skeleton'
@@ -17,6 +17,7 @@ const Search = () => {
 
   const queryParam = searchParams.get('q') || ''
   const typeParam = (searchParams.get('type') as SearchType) || 'all'
+  const pageParam = parseInt(searchParams.get('page') || '1')
 
   const [searchQuery, setSearchQuery] = useState(queryParam)
   const [searchType, setSearchType] = useState<SearchType>(typeParam)
@@ -29,7 +30,14 @@ const Search = () => {
   const [hasMore, setHasMore] = useState(true)
   const [isFetchingMore, setIsFetchingMore] = useState(false)
 
-  const pageSize = '30'
+  // Track page positions and ref for scrolling
+  const [pagePositions, setPagePositions] = useState<{
+    [page: number]: number
+  }>({})
+  const bookListRef = useRef<HTMLDivElement>(null)
+  const initialLoadComplete = useRef(false)
+
+  const pageSize = 18
 
   useEffect(() => {
     if (queryParam.trim()) {
@@ -38,13 +46,48 @@ const Search = () => {
       setIsFetchingMore(false)
       setHasMore(true)
       setPage(1)
+      setPagePositions({})
+      initialLoadComplete.current = false
 
-      handleFetch(queryParam, typeParam, pageSize, 1) // ← force it!
+      // fetches all previous pages sequentially, so if user is on page 4, we fetch pages 1, 2, and 3 also
+      const fetchAllPagesUpTo = async () => {
+        for (let p = 1; p <= pageParam; p++) {
+          await handleFetch(queryParam, typeParam, pageSize.toString(), p)
+          setPage(p)
+
+          // Track the starting index for each page, so pg 1 will have index 0 and start at 0, pg 2 has index 1 and starts at 30 etc.
+          setPagePositions((prev) => ({
+            ...prev,
+            [p]: (p - 1) * pageSize,
+          }))
+        }
+        initialLoadComplete.current = true
+      }
+
+      fetchAllPagesUpTo()
     } else {
       setBooks([])
       setSearchCompleted(false)
     }
   }, [queryParam, typeParam])
+
+  // Scroll to the correct position once initial loading completes
+  useEffect(() => {
+    if (initialLoadComplete.current && pageParam > 1 && bookListRef.current) {
+      const scrollToPosition = pagePositions[pageParam] || 0
+
+      // Find the element at the specified position
+      if (scrollToPosition < books.length) {
+        const bookElements = bookListRef.current.querySelectorAll('.book-item')
+        if (bookElements && bookElements[scrollToPosition]) {
+          bookElements[scrollToPosition].scrollIntoView({
+            behavior: 'auto',
+            block: 'start',
+          })
+        }
+      }
+    }
+  }, [books, pagePositions, pageParam, initialLoadComplete.current])
 
   const handleFetch = async (
     query: string,
@@ -85,21 +128,27 @@ const Search = () => {
 
   const loadMoreRef = useInfiniteScroll(() => {
     if (!isFetchingMore && hasMore) {
-      handleFetch(queryParam, typeParam, pageSize, page + 1)
-      setPage((prev) => prev + 1)
+      const nextPage = page + 1
+      handleFetch(queryParam, typeParam, pageSize.toString(), nextPage)
+      setPage(nextPage)
+
+      const params = new URLSearchParams(searchParams.toString())
+      params.set('page', nextPage.toString())
+      router.replace(`/search?${params.toString()}`, { scroll: false })
+
+      // Track this new page's position
+      setPagePositions((prev) => ({
+        ...prev,
+        [nextPage]: books.length,
+      }))
     }
   }, hasMore)
 
   const handleSearch = (query: string, type: SearchType = 'all') => {
-    // If the search parameters haven't changed, don't trigger a new search
-    if (query === searchQuery && type === searchType) {
-      return
-    }
-
     setSearchQuery(query)
     setSearchType(type)
 
-    router.push(`/search?q=${encodeURIComponent(query)}&type=${type}`)
+    router.push(`/search?q=${encodeURIComponent(query)}&type=${type}&page=1`)
   }
 
   const showNoResults =
@@ -126,11 +175,11 @@ const Search = () => {
       )}
 
       {!loading && books.length > 0 && (
-        <>
+        <div ref={bookListRef}>
           <BookList books={books} />
           {isFetchingMore && <BookListSkeleton />}
           <div ref={loadMoreRef} className="h-10" />
-        </>
+        </div>
       )}
     </div>
   )

--- a/components/search/search-bar.tsx
+++ b/components/search/search-bar.tsx
@@ -15,25 +15,22 @@ import {
 import { useState } from 'react'
 
 interface SearchBarProps {
-  onSearch: (query: string, type: SearchType, limit: string) => void
+  onSearch: (query: string, type: SearchType) => void
   initialQuery?: string
   initialType?: SearchType
-  initialLimit?: string
 }
 
 const SearchBar = ({
   onSearch,
   initialQuery = '',
   initialType = 'all',
-  initialLimit = '20',
 }: SearchBarProps) => {
   const [query, setQuery] = useState(initialQuery)
   const [type, setType] = useState<SearchType>(initialType)
-  const [limit, setLimit] = useState<string>(initialLimit)
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
-    onSearch(query, type, limit)
+    onSearch(query, type)
   }
 
   return (
@@ -73,22 +70,7 @@ const SearchBar = ({
         value={query}
         onChange={(e) => setQuery(e.target.value)}
       />
-      <Select onValueChange={(value) => setLimit(value)} value={limit}>
-        <SelectTrigger
-          className="w-full md:w-[180px] self-start md:self-auto"
-          aria-label="display number of books"
-        >
-          <SelectValue placeholder="Display" />
-        </SelectTrigger>
-        <SelectContent>
-          <SelectGroup>
-            <SelectLabel>Display</SelectLabel>
-            <SelectItem value="20">20</SelectItem>
-            <SelectItem value="50">50</SelectItem>
-            <SelectItem value="100">100</SelectItem>
-          </SelectGroup>
-        </SelectContent>
-      </Select>
+
       <Button type="submit" className="md:self-auto w-full md:w-auto">
         Search
       </Button>

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -51,11 +51,12 @@ const getLiteBooks = (searchData: any) => {
 export const fetchBooksLite = async (
   query: string,
   type: SearchType = 'all',
-  limit: string = '20'
+  limit: string,
+  page: number = 1
 ): Promise<BookLite[]> => {
   if (!query) return []
 
-  let searchUrl = `${BASE_URL}/search.json?limit=${limit}`
+  let searchUrl = `${BASE_URL}/search.json?limit=${limit}&page=${page}`
   if (type === 'title') {
     searchUrl += `&title=${encodeURIComponent(query)}`
   } else if (type === 'author') {

--- a/lib/hooks/useInfiniteScroll.ts
+++ b/lib/hooks/useInfiniteScroll.ts
@@ -1,0 +1,22 @@
+import { useEffect, useRef } from 'react'
+
+export const useInfiniteScroll = (callback: () => void, hasMore: boolean) => {
+  const loadMoreRef = useRef<HTMLDivElement | null>(null)
+
+  useEffect(() => {
+    if (!hasMore) return
+
+    const observer = new IntersectionObserver(([entry]) => {
+      if (entry.isIntersecting) {
+        callback()
+      }
+    })
+
+    const elem = loadMoreRef.current
+    if (elem) observer.observe(elem)
+    return () => {
+      if (elem) observer.unobserve(elem)
+    }
+  }, [callback, hasMore])
+  return loadMoreRef
+}


### PR DESCRIPTION
This PR does a bunch:
- adds a useInfiniteScroll hook
- adds infinite scroll to the search results
- ensures that users scroll position is saved on back/forwards navigation
- adds a back to top button that resets the url and `books` array to page 1
- removes the `limit` prop in the `SearchBar`
- removes the 'display' <number> drop down in the `SearchBar`