### PR TITLE
Fix/try to fix janky scroll

### DIFF
--- a/components/search/book-list.tsx
+++ b/components/search/book-list.tsx
@@ -4,8 +4,8 @@ import BookListCard from './book-list-card'
 const BookList = ({ books }: { books: BookLite[] }) => {
   return (
     <div className="mt-8 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8 max-w-6xl mx-auto px-4 ">
-      {books.map((book, i) => (
-        <BookListCard key={i} book={book} />
+      {books.map((book) => (
+        <BookListCard key={book.workId} book={book} />
       ))}
     </div>
   )

--- a/components/search/index.tsx
+++ b/components/search/index.tsx
@@ -4,12 +4,14 @@ import { Book } from '@/interfaces'
 import { SearchType } from '@/types'
 import { useSearchParams } from 'next/navigation'
 import { useRouter } from 'next/navigation'
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import SearchBar from './search-bar'
 import { fetchBooksLite } from '@/lib/api'
 import BookListSkeleton from './book-list-skeleton'
 import BookList from './book-list'
 import { useInfiniteScroll } from '@/lib/hooks/useInfiniteScroll'
+import { Button } from '../ui/button'
+import { ChevronUp } from 'lucide-react'
 
 const Search = () => {
   const router = useRouter()
@@ -17,6 +19,7 @@ const Search = () => {
 
   const queryParam = searchParams.get('q') || ''
   const typeParam = (searchParams.get('type') as SearchType) || 'all'
+  const offsetParam = parseInt(searchParams.get('offset') || '0')
 
   const [searchQuery, setSearchQuery] = useState(queryParam)
   const [searchType, setSearchType] = useState<SearchType>(typeParam)
@@ -29,70 +32,153 @@ const Search = () => {
   const [isFetchingMore, setIsFetchingMore] = useState(false)
   const [hasMore, setHasMore] = useState(true)
 
+  const bookListRef = useRef<HTMLDivElement>(null)
+  const fetchedOffsets = useRef<Set<number>>(new Set())
+  const fetchedWorkIds = useRef<Set<string>>(new Set())
+
   const limit = 18
 
-  const loadMoreRef = useInfiniteScroll(() => {
-    if (!isFetchingMore && hasMore) {
-      const nextOffset = offset + limit
-      fetchMoreBooks(nextOffset)
-    }
-  }, hasMore)
+  const fetchAllUpToOffset = async (targetOffset: number) => {
+    fetchedOffsets.current.clear()
+    fetchedWorkIds.current.clear() // reset tracked workIds
 
-  const fetchMoreBooks = async (newOffset: number) => {
-    setIsFetchingMore(true)
-    try {
-      const results = await fetchBooksLite(
-        queryParam,
-        typeParam,
-        String(limit),
-        newOffset
-      )
-      setBooks((prev) => [...prev, ...results])
-      setOffset(newOffset)
-      if (results.length < limit) setHasMore(false)
-    } catch (err) {
-      console.error(err)
-      setHasMore(false)
-    } finally {
-      setIsFetchingMore(false)
-    }
-  }
-
-  useEffect(() => {
-    if (queryParam.trim()) {
-      handleFetch(queryParam, typeParam, 0)
-    } else {
-      setBooks([])
-      setSearchCompleted(false)
-    }
-  }, [queryParam, typeParam])
-
-  const handleFetch = async (
-    query: string,
-    type: SearchType,
-    offset: number
-  ) => {
-    setLoading(true)
-    setError(null)
+    setBooks([])
+    setOffset(targetOffset)
+    setHasMore(true)
     setSearchCompleted(false)
+    setLoading(true)
+
+    const pagesToFetch = Math.ceil((targetOffset + 1) / limit)
 
     try {
-      const results = await fetchBooksLite(query, type, String(limit), offset)
-      setBooks(results)
-      console.log(results)
+      for (let i = 0; i < pagesToFetch; i++) {
+        const currentOffset = i * limit
+        if (!fetchedOffsets.current.has(currentOffset)) {
+          const results = await fetchBooksLite(
+            queryParam,
+            typeParam,
+            limit,
+            currentOffset
+          )
+
+          // dedupe based on workId
+          const uniqueResults = results.filter((book) => {
+            if (!fetchedWorkIds.current.has(book.workId)) {
+              fetchedWorkIds.current.add(book.workId)
+              return true
+            }
+            return false
+          })
+          setBooks((prev) => [...prev, ...uniqueResults])
+
+          if (results.length < limit) {
+            setHasMore(false)
+            break
+          }
+        }
+      }
+      fetchedOffsets.current.add(targetOffset)
     } catch (err) {
       console.error(err)
       setError('Something went wrong while fetching books.')
+      setHasMore(false)
     } finally {
       setLoading(false)
       setSearchCompleted(true)
     }
   }
 
+  useEffect(() => {
+    if (queryParam.trim()) {
+      fetchAllUpToOffset(offsetParam)
+    } else {
+      setBooks([])
+      setSearchCompleted(false)
+    }
+  }, [queryParam, typeParam])
+
+  useEffect(() => {
+    if (offsetParam > 0 && books.length > 0) {
+      const bookElements = document.querySelectorAll('.book-item')
+      if (bookElements[offsetParam]) {
+        bookElements[offsetParam].scrollIntoView({
+          behavior: 'smooth',
+          block: 'nearest',
+        })
+      }
+    }
+  }, [books, offsetParam])
+
+  const handleFetch = async (
+    query: string,
+    type: SearchType,
+    limit: number,
+    offset: number
+  ) => {
+    if (fetchedOffsets.current.has(offset)) return
+    fetchedOffsets.current.add(offset)
+
+    setError(null)
+    if (offset === 0) {
+      setLoading(true)
+      setBooks([])
+      fetchedWorkIds.current.clear() // reset here too
+      setSearchCompleted(false)
+    } else {
+      setIsFetchingMore(true)
+    }
+
+    try {
+      const results = await fetchBooksLite(query, type, limit, offset)
+
+      const uniqueResults = results.filter((book) => {
+        if (!fetchedWorkIds.current.has(book.workId)) {
+          fetchedWorkIds.current.add(book.workId)
+          return true
+        }
+        return false
+      })
+      setBooks((prev) => [...prev, ...uniqueResults])
+      setHasMore(results.length === limit)
+    } catch (err) {
+      console.error(err)
+      setError('Something went wrong while fetching books.')
+      setHasMore(false)
+    } finally {
+      setIsFetchingMore(false)
+    }
+  }
+
+  const loadMoreRef = useInfiniteScroll(() => {
+    if (!isFetchingMore && hasMore) {
+      const newOffset = offset + limit
+      handleFetch(queryParam, typeParam, limit, newOffset)
+      setOffset(newOffset)
+
+      const params = new URLSearchParams(searchParams.toString())
+      params.set('offset', newOffset.toString())
+      router.replace(`/search?${params.toString()}`, { scroll: false })
+    }
+  }, hasMore)
+
   const handleSearch = (query: string, type: SearchType = 'all') => {
     setSearchQuery(query)
     setSearchType(type)
-    router.push(`/search?q=${encodeURIComponent(query)}&type=${type}`)
+    setOffset(0)
+
+    router.push(`/search?q=${encodeURIComponent(query)}&type=${type}&offset=0`)
+  }
+
+  const handleBackToTop = async () => {
+    window.scrollTo({ top: 0, behavior: 'smooth' })
+
+    const params = new URLSearchParams(searchParams.toString())
+    params.set('offset', '0')
+    router.replace(`/search?${params.toString()}`, { scroll: false })
+
+    setTimeout(() => {
+      fetchAllUpToOffset(0)
+    }, 500)
   }
 
   const showNoResults =
@@ -120,9 +206,22 @@ const Search = () => {
 
       {!loading && books.length > 0 && (
         <>
-          <BookList books={books} />
-          {isFetchingMore && <BookListSkeleton />}
-          <div ref={loadMoreRef} className="h-10" />
+          <div ref={bookListRef}>
+            <BookList books={books} />
+            {isFetchingMore && <BookListSkeleton />}
+            <div ref={loadMoreRef} className="h-10" />
+          </div>
+
+          {offset > 0 && (
+            <Button
+              className="fixed bottom-10 right-10 rounded-full cursor-pointer shadow-md hover:shadow-lg hover:animate-bounce"
+              onClick={handleBackToTop}
+              size="icon"
+              aria-label="back to top"
+            >
+              <ChevronUp />
+            </Button>
+          )}
         </>
       )}
     </div>

--- a/components/search/index.tsx
+++ b/components/search/index.tsx
@@ -4,14 +4,11 @@ import { Book } from '@/interfaces'
 import { SearchType } from '@/types'
 import { useSearchParams } from 'next/navigation'
 import { useRouter } from 'next/navigation'
-import { useEffect, useState, useRef } from 'react'
+import { useEffect, useState } from 'react'
 import SearchBar from './search-bar'
 import { fetchBooksLite } from '@/lib/api'
 import BookListSkeleton from './book-list-skeleton'
 import BookList from './book-list'
-import { useInfiniteScroll } from '@/lib/hooks/useInfiniteScroll'
-import { Button } from '../ui/button'
-import { ChevronUp } from 'lucide-react'
 
 const Search = () => {
   const router = useRouter()
@@ -19,7 +16,6 @@ const Search = () => {
 
   const queryParam = searchParams.get('q') || ''
   const typeParam = (searchParams.get('type') as SearchType) || 'all'
-  const pageParam = parseInt(searchParams.get('page') || '1')
 
   const [searchQuery, setSearchQuery] = useState(queryParam)
   const [searchType, setSearchType] = useState<SearchType>(typeParam)
@@ -28,139 +24,43 @@ const Search = () => {
   const [error, setError] = useState<string | null>(null)
   const [searchCompleted, setSearchCompleted] = useState(false)
 
-  const [page, setPage] = useState(1)
-  const [hasMore, setHasMore] = useState(true)
-  const [isFetchingMore, setIsFetchingMore] = useState(false)
-
-  // Track page positions and ref for scrolling
-  const [pagePositions, setPagePositions] = useState<{
-    [page: number]: number
-  }>({})
-  const bookListRef = useRef<HTMLDivElement>(null)
-  const initialLoadComplete = useRef(false)
-
-  const pageSize = 18
-
-  const fetchAllPagesUpTo = async (targetPage: number) => {
-    setBooks([])
-    setSearchCompleted(false)
-    setIsFetchingMore(false)
-    setHasMore(true)
-    setPage(1)
-    setPagePositions({})
-    initialLoadComplete.current = false
-
-    for (let p = 1; p <= targetPage; p++) {
-      await handleFetch(queryParam, typeParam, pageSize.toString(), p)
-      setPage(p)
-      setPagePositions((prev) => ({
-        ...prev,
-        [p]: (p - 1) * pageSize,
-      }))
-    }
-
-    initialLoadComplete.current = true
-  }
+  const limit = 18
 
   useEffect(() => {
     if (queryParam.trim()) {
-      fetchAllPagesUpTo(pageParam)
+      handleFetch(queryParam, typeParam, 0)
     } else {
       setBooks([])
       setSearchCompleted(false)
     }
   }, [queryParam, typeParam])
 
-  // Scroll to the correct position once initial loading completes
-  useEffect(() => {
-    if (initialLoadComplete.current && pageParam > 1 && bookListRef.current) {
-      const scrollToPosition = pagePositions[pageParam] || 0
-
-      // Find the element at the specified position
-      if (scrollToPosition < books.length) {
-        const bookElements = bookListRef.current.querySelectorAll('.book-item')
-        if (bookElements && bookElements[scrollToPosition]) {
-          bookElements[scrollToPosition].scrollIntoView({
-            behavior: 'auto',
-            block: 'start',
-          })
-        }
-      }
-    }
-  }, [books, pagePositions, pageParam, initialLoadComplete.current])
-
   const handleFetch = async (
     query: string,
     type: SearchType,
-    limit: string,
-    page: number
+    offset: number
   ) => {
-    if (page === 1) {
-      setLoading(true)
-      setBooks([])
-    } else {
-      setIsFetchingMore(true)
-    }
-
+    setLoading(true)
     setError(null)
-    if (page === 1) setSearchCompleted(false)
+    setSearchCompleted(false)
 
     try {
-      const results = await fetchBooksLite(query, type, limit, page)
-
-      if (page === 1) {
-        setBooks(results)
-      } else {
-        setBooks((prev) => [...prev, ...results])
-      }
-
-      setHasMore(results.length === parseInt(limit))
+      const results = await fetchBooksLite(query, type, String(limit), offset)
+      setBooks(results)
+      console.log(results)
     } catch (err) {
       console.error(err)
       setError('Something went wrong while fetching books.')
-      setHasMore(false)
     } finally {
       setLoading(false)
-      setIsFetchingMore(false)
       setSearchCompleted(true)
     }
   }
 
-  const loadMoreRef = useInfiniteScroll(() => {
-    if (!isFetchingMore && hasMore) {
-      const nextPage = page + 1
-      handleFetch(queryParam, typeParam, pageSize.toString(), nextPage)
-      setPage(nextPage)
-
-      const params = new URLSearchParams(searchParams.toString())
-      params.set('page', nextPage.toString())
-      router.replace(`/search?${params.toString()}`, { scroll: false })
-
-      // Track this new page's position
-      setPagePositions((prev) => ({
-        ...prev,
-        [nextPage]: books.length,
-      }))
-    }
-  }, hasMore)
-
   const handleSearch = (query: string, type: SearchType = 'all') => {
     setSearchQuery(query)
     setSearchType(type)
-
-    router.push(`/search?q=${encodeURIComponent(query)}&type=${type}&page=1`)
-  }
-
-  const handleBackToTop = async () => {
-    window.scrollTo({ top: 0, behavior: 'smooth' })
-
-    const params = new URLSearchParams(searchParams.toString())
-    params.set('page', '1')
-    router.replace(`/search?${params.toString()}`, { scroll: false })
-
-    setTimeout(() => {
-      fetchAllPagesUpTo(1)
-    }, 500)
+    router.push(`/search?q=${encodeURIComponent(query)}&type=${type}`)
   }
 
   const showNoResults =
@@ -186,25 +86,7 @@ const Search = () => {
         </div>
       )}
 
-      {!loading && books.length > 0 && (
-        <>
-          <div ref={bookListRef}>
-            <BookList books={books} />
-            {isFetchingMore && <BookListSkeleton />}
-            <div ref={loadMoreRef} className="h-10" />
-          </div>
-          {page > 1 && (
-            <Button
-              className="fixed bottom-10 right-10 rounded-full cursor-pointer shadow-md hover:shadow-lg hover:animate-bounce"
-              onClick={handleBackToTop}
-              size="icon"
-              aria-label="back to top"
-            >
-              <ChevronUp />
-            </Button>
-          )}
-        </>
-      )}
+      {!loading && books.length > 0 && <BookList books={books} />}
     </div>
   )
 }

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -52,11 +52,11 @@ export const fetchBooksLite = async (
   query: string,
   type: SearchType = 'all',
   limit: string,
-  page: number = 1
+  offset: number
 ): Promise<BookLite[]> => {
   if (!query) return []
 
-  let searchUrl = `${BASE_URL}/search.json?limit=${limit}&page=${page}`
+  let searchUrl = `${BASE_URL}/search.json?limit=${limit}&offset=${offset}`
   if (type === 'title') {
     searchUrl += `&title=${encodeURIComponent(query)}`
   } else if (type === 'author') {

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -51,7 +51,7 @@ const getLiteBooks = (searchData: any) => {
 export const fetchBooksLite = async (
   query: string,
   type: SearchType = 'all',
-  limit: string,
+  limit: number = 18,
   offset: number
 ): Promise<BookLite[]> => {
   if (!query) return []


### PR DESCRIPTION
This PR FIXED THE JANKY, NO GOOD, DUPLICATING INFINITE SCROLL!
- used `offset` instead of `page` for 'pagination'
- added `offset` param to the url
- uses a `Set` (`fetchedOffsets`) to prevent re-fetching duplicate offsets.
- adds scroll restoration on back/forward navigation using above `fetchedOffsets`
- adds some buttery smooth scrolling behaviour with basically no jank
- made it so I never want to see this component ever again in my life